### PR TITLE
Fix unicode error

### DIFF
--- a/ink2canvas/svg/AbstractShape.py
+++ b/ink2canvas/svg/AbstractShape.py
@@ -27,7 +27,7 @@ class AbstractShape(Element):
                 parent = parent.getParent()        
         
         #remove any trailing space in dict keys/values
-        style = dict([(str.strip(k), str.strip(v)) for k,v in style.items()])
+        style = dict([(str.strip(str(k)), str.strip(str(v))) for k,v in style.items()])
         return style
 
     def setStyle(self, style):


### PR DESCRIPTION
Made a shape in inkscape portable that decided to insert unicode somewhere into the styles, resulting in the export to html failing completely. Wrapping the getStyle strip() chars in a str() method seemed to fix it.